### PR TITLE
Integrate Glossy Touch templates

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, url_for
+from flask import Blueprint, render_template, redirect, url_for, request, flash
 from flask_login import login_required, current_user
 from ..models import Challenge, UserProgress, db
 from ..utils import select_daily_challenge_for
@@ -33,7 +33,13 @@ def complete(challenge_id):
     # Optionally update streak if this is first solve today
     return redirect(url_for("main.dashboard"))
 
-@main_bp.route("/profile")
+@main_bp.route("/profile", methods=["GET", "POST"])
 @login_required
 def profile():
+    if request.method == "POST":
+        langs = request.form.get("languages", "")
+        current_user.preferred_languages = langs
+        db.session.commit()
+        flash("Preferences updated.", "success")
+        return redirect(url_for("main.profile"))
     return render_template("profile.html", user=current_user)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,37 +1,39 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <title>{% block title %}SyntaxSnacks{% endblock %}</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <!-- include Glossy Touch CSS -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}SyntaxSnacks{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='templatemo-glossy-touch.css') }}">
 </head>
 <body>
-  <nav>
-    <a href="{{ url_for('main.dashboard') }}">Home</a>
-    {% if current_user.is_authenticated %}
-      <span>Hi {{ current_user.username }}</span>
-      <a href="{{ url_for('main.profile') }}">Profile</a>
-      <a href="{{ url_for('auth.logout') }}">Logout</a>
-    {% else %}
-      <a href="{{ url_for('auth.login') }}">Login</a>
-      <a href="{{ url_for('auth.signup') }}">Sign Up</a>
-    {% endif %}
-  </nav>
-  <main>
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
+    <div class="bg-shapes">
+        <div class="shape"></div>
+        <div class="shape"></div>
+        <div class="shape"></div>
+        <div class="shape"></div>
+        <div class="shape"></div>
+        <div class="shape"></div>
+    </div>
+
+    {% include 'partials/_header.html' %}
+
+    <div class="container">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
         <div class="flash-container">
-          {% for category, msg in messages %}
-            <div class="flash {{ category }}">{{ msg }}</div>
-          {% endfor %}
+            {% for category, msg in messages %}
+            <div class="alert {{ category }} glass">{{ msg }}</div>
+            {% endfor %}
         </div>
-      {% endif %}
-    {% endwith %}
-    {% block content %}{% endblock %}
-  </main>
-  <!-- your JS -->
-  <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+        {% endif %}
+        {% endwith %}
+
+        {% block content %}{% endblock %}
+    </div>
+
+    {% include 'partials/_footer.html' %}
+
+    <script src="{{ url_for('static', filename='templatemo-glossy-touch.js') }}"></script>
 </body>
 </html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,33 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Dashboard – SyntaxSnacks{% endblock %}
 {% block content %}
-  <h1>Today's SyntaxSnack</h1>
-
-  {% if user %}
-    <p>Streak: {{ user.streak }} day(s)</p>
-    <p>Preferred languages: {{ user.preferred_languages }}</p>
-  {% endif %}
-
-  {% if challenge %}
-    <div class="challenge-card">
-      <h2>{{ challenge.title }} ({{ challenge.language }})</h2>
-      <p>{{ challenge.prompt }}</p>
-      <div>
-        <button onclick="document.getElementById('hint').style.display='block'">Show Hint</button>
-        <div id="hint" style="display:none;">
-          {% for h in challenge.get_hints() %}
-            <p>• {{ h }}</p>
-          {% endfor %}
-        </div>
-      </div>
-      <form method="POST" action="{{ url_for('main.complete', challenge_id=challenge.id) }}">
-        <button type="submit">Mark as Solved</button>
-      </form>
-      {% if challenge.reference_url %}
-        <p>Learn more: <a href="{{ challenge.reference_url }}" target="_blank">Reference</a></p>
-      {% endif %}
-    </div>
-  {% else %}
-    <p>No new challenges available. Check back tomorrow or contribute more content.</p>
-  {% endif %}
+<h1>Today's SyntaxSnack</h1>
+{% include 'partials/_challenge_card.html' %}
 {% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,13 +1,20 @@
 {% extends "base.html" %}
 {% block title %}Login – SyntaxSnacks{% endblock %}
 {% block content %}
-  <h2>Log In</h2>
-  <form method="POST" action="{{ url_for('auth.login') }}">
-    <label>Username</label>
-    <input name="username" required />
-    <label>Password</label>
-    <input type="password" name="password" required />
-    <button type="submit">Log In</button>
-  </form>
-  <p>Don't have an account? <a href="{{ url_for('auth.signup') }}">Sign up</a></p>
+<div class="auth-form glass">
+    <h2>Log In</h2>
+    <form method="POST" action="{{ url_for('auth.login') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="form-group">
+            <label for="username">Username</label>
+            <input id="username" name="username" required />
+        </div>
+        <div class="form-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required />
+        </div>
+        <button type="submit" class="cta-button">Log In</button>
+    </form>
+    <p>Don't have an account? <a href="{{ url_for('auth.signup') }}">Sign up</a></p>
+</div>
 {% endblock %}

--- a/app/templates/partials/_challenge_card.html
+++ b/app/templates/partials/_challenge_card.html
@@ -1,0 +1,21 @@
+{% if challenge %}
+<section class="challenge-card glass">
+    <h2>{{ challenge.title }} <small>({{ challenge.language }})</small></h2>
+    <p>{{ challenge.prompt }}</p>
+    <button class="cta-button" type="button" onclick="document.getElementById('hint').classList.toggle('show')">Show Hint</button>
+    <div id="hint" class="hint" style="display:none;" onclick="this.style.display='none'">
+        {% for h in challenge.get_hints() %}
+        <p>• {{ h }}</p>
+        {% endfor %}
+    </div>
+    {% if challenge.reference_url %}
+    <p>Learn more: <a href="{{ challenge.reference_url }}" target="_blank">Reference</a></p>
+    {% endif %}
+    <form method="POST" action="{{ url_for('main.complete', challenge_id=challenge.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="cta-button">Mark as Solved</button>
+    </form>
+</section>
+{% else %}
+<p>No new challenges available. Check back tomorrow or contribute more content.</p>
+{% endif %}

--- a/app/templates/partials/_footer.html
+++ b/app/templates/partials/_footer.html
@@ -1,0 +1,18 @@
+<div id="footer">
+    <div class="container">
+        <footer class="glass">
+            <div class="footer-content">
+                <div class="footer-links">
+                    <a href="#" onclick="return false;">About Us</a>
+                    <a href="#" onclick="return false;">Privacy Policy</a>
+                    <a href="#" onclick="return false;">Terms of Service</a>
+                    <a href="#" onclick="return false;">XML Sitemap</a>
+                    <a href="#" onclick="return false;">Contact</a>
+                </div>
+                <div class="copyright">
+                    &copy; 2025 SyntaxSnacks. All rights reserved. Powered by Glossy Touch theme.
+                </div>
+            </div>
+        </footer>
+    </div>
+</div>

--- a/app/templates/partials/_header.html
+++ b/app/templates/partials/_header.html
@@ -1,0 +1,39 @@
+<header>
+    <div class="container">
+        <nav class="glass">
+            <div class="logo">
+                <div class="logo-icon">
+                    <svg viewBox="0 0 48 48" fill="white" xmlns="http://www.w3.org/2000/svg">
+                        <circle cx="16" cy="16" r="5" opacity="0.9"/>
+                        <circle cx="32" cy="16" r="4" opacity="0.8"/>
+                        <circle cx="16" cy="32" r="4" opacity="0.7"/>
+                        <circle cx="32" cy="32" r="5" opacity="0.85"/>
+                        <circle cx="24" cy="8" r="2" opacity="1"/>
+                        <circle cx="8" cy="24" r="2" opacity="0.9"/>
+                        <circle cx="40" cy="24" r="2" opacity="0.9"/>
+                        <circle cx="24" cy="40" r="2" opacity="1"/>
+                        <circle cx="8" cy="8" r="1" opacity="0.6"/>
+                        <circle cx="40" cy="8" r="1" opacity="0.6"/>
+                        <circle cx="8" cy="40" r="1" opacity="0.6"/>
+                        <circle cx="40" cy="40" r="1" opacity="0.6"/>
+                    </svg>
+                </div>
+                <span>SyntaxSnacks</span>
+            </div>
+            <div class="nav-links">
+                <a href="{{ url_for('main.dashboard') }}">Home</a>
+                {% if current_user.is_authenticated %}
+                    <span class="user-info">Hi {{ current_user.username }} – Streak {{ current_user.streak }}</span>
+                    <a href="{{ url_for('main.profile') }}">Settings</a>
+                    <a href="{{ url_for('auth.logout') }}">Logout</a>
+                {% else %}
+                    <a href="{{ url_for('auth.login') }}">Login</a>
+                    <a href="{{ url_for('auth.signup') }}">Sign Up</a>
+                {% endif %}
+            </div>
+        </nav>
+        {% if current_user.is_authenticated %}
+        <div class="user-langs">Your languages: {{ current_user.preferred_languages }}</div>
+        {% endif %}
+    </div>
+</header>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Settings – SyntaxSnacks{% endblock %}
+{% block content %}
+<div class="settings-form glass">
+    <h2>Update Preferences</h2>
+    <form method="POST" action="{{ url_for('main.profile') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="form-group">
+            <label for="languages">Preferred Languages (comma-separated)</label>
+            <input id="languages" name="languages" value="{{ user.preferred_languages }}" />
+        </div>
+        <button type="submit" class="cta-button">Save</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -1,15 +1,24 @@
 {% extends "base.html" %}
 {% block title %}Sign Up – SyntaxSnacks{% endblock %}
 {% block content %}
-  <h2>Create Account</h2>
-  <form method="POST" action="{{ url_for('auth.signup') }}">
-    <label>Username</label>
-    <input name="username" required />
-    <label>Password</label>
-    <input type="password" name="password" required />
-    <label>Preferred Languages (comma-separated)</label>
-    <input name="languages" placeholder="Python,JavaScript" />
-    <button type="submit">Sign Up</button>
-  </form>
-  <p>Already have one? <a href="{{ url_for('auth.login') }}">Log in</a></p>
+<div class="auth-form glass">
+    <h2>Create Account</h2>
+    <form method="POST" action="{{ url_for('auth.signup') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="form-group">
+            <label for="username">Username</label>
+            <input id="username" name="username" required />
+        </div>
+        <div class="form-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required />
+        </div>
+        <div class="form-group">
+            <label for="languages">Preferred Languages (comma-separated)</label>
+            <input id="languages" name="languages" placeholder="Python,JavaScript" />
+        </div>
+        <button type="submit" class="cta-button">Sign Up</button>
+    </form>
+    <p>Already have one? <a href="{{ url_for('auth.login') }}">Log in</a></p>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace simple templates with Glossy Touch layout
- split header, footer and challenge card into partials
- style auth and profile forms and include CSRF tokens
- add preference saving route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cb2b5bd70832a9f2062333b0a91b7