### PR TITLE
Add visitor-friendly homepage

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -9,7 +9,8 @@ main_bp = Blueprint("main", __name__)
 def index():
     if current_user.is_authenticated:
         return redirect(url_for("main.dashboard"))
-    return render_template("dashboard.html", user=None, challenge=None)
+    # show marketing home page for visitors
+    return render_template("home.html")
 
 @main_bp.route("/dashboard")
 @login_required

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Welcome – SyntaxSnacks{% endblock %}
+{% block content %}
+<section class="hero glass">
+    <div class="hero-image">
+        <img src="{{ url_for('static', filename='images/templatemo-futuristic-girl.jpg') }}" alt="Programming illustration" />
+    </div>
+    <div class="hero-content">
+        <h1>Sharpen Your Skills</h1>
+        <p>Daily bite-sized challenges help you practice consistently. Sign up and start solving!</p>
+        <a href="{{ url_for('auth.signup') }}" class="cta-button">Get Started</a>
+    </div>
+</section>
+
+<section class="features">
+    <div class="feature-card glass">
+        <div class="feature-icon">🧩</div>
+        <h3>Daily Challenges</h3>
+        <p>Short exercises across multiple languages.</p>
+    </div>
+    <div class="feature-card glass">
+        <div class="feature-icon">📊</div>
+        <h3>Track Progress</h3>
+        <p>Build a streak and watch your skills grow.</p>
+    </div>
+    <div class="feature-card glass">
+        <div class="feature-icon">🎯</div>
+        <h3>Choose Languages</h3>
+        <p>Practice Python, JavaScript, C++, and more.</p>
+    </div>
+</section>
+{% endblock %}

--- a/app/templates/partials/_header.html
+++ b/app/templates/partials/_header.html
@@ -21,7 +21,7 @@
                 <span>SyntaxSnacks</span>
             </div>
             <div class="nav-links">
-                <a href="{{ url_for('main.dashboard') }}">Home</a>
+                <a href="{{ url_for('main.dashboard') if current_user.is_authenticated else url_for('main.index') }}">Home</a>
                 {% if current_user.is_authenticated %}
                     <span class="user-info">Hi {{ current_user.username }} – Streak {{ current_user.streak }}</span>
                     <a href="{{ url_for('main.profile') }}">Settings</a>


### PR DESCRIPTION
## Summary
- show a static marketing home page for visitors
- adjust header navigation so Home links to dashboard only for logged in users
- include new home.html based on original template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cbaadcd7c832a957b9e3a455bd374