### PR TITLE
Add license and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+We welcome pull requests to improve SyntaxSnacks. To get started:
+
+1. Fork the repository and create your branch from `main`.
+2. Add your changes with clear commit messages.
+3. Ensure all Python files compile with `python -m py_compile $(git ls-files '*.py')`.
+4. Submit a pull request.
+
+Please read the [LICENSE](LICENSE) before contributing.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Selcuk Ata Aksoy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ syntaxsnacks/
 │   ├── utils.py
 │   └── templates/
 │       ├── base.html
+│       ├── home.html
 │       ├── login.html
 │       ├── signup.html
 │       ├── dashboard.html
-│       └── profile.html
+│       ├── profile.html
+│       └── partials/
+│           ├── _header.html
+│           ├── _footer.html
+│           └── _challenge_card.html
 ├── static/                  # Glossy Touch assets (css/, js/, images/)
 ├── seed.py                  # helper to seed initial challenges/jokes
 └── README.md
@@ -51,10 +56,11 @@ syntaxsnacks/
 
 ## 🏗️ Current Status
 
-✅ Basic backend (Python / Flask) with authentication and session management  
-✅ Simple frontend (HTML / CSS / vanilla JS, based on Glossy Touch)  
-✅ Challenge engine with language preferences  
-✅ Progress tracking (streaks, solved)  
+✅ Basic backend (Python / Flask) with authentication and session management
+✅ Glossy Touch-inspired UI with modular Jinja templates
+✅ Visitor-friendly landing page for guests
+✅ Challenge engine with language preferences
+✅ Progress tracking (streaks, solved)
 🔜 LLM-assisted content pipeline (human-reviewed)  
 🔜 Desktop/PWA packaging and deeper personalization  
 🔜 Admin / content moderation tools  
@@ -130,7 +136,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## 📚 License
 
-MIT — do whatever you want, just don’t remove the cookies.
+MIT — do whatever you want, just don’t remove the cookies. See
+[LICENSE](LICENSE) for the full text.
 
 ---
 


### PR DESCRIPTION
## Summary
- add MIT LICENSE file
- create a basic CONTRIBUTING guide
- link README to LICENSE

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688cbca0c170832abd3dee99d7d0cc37