### PR TITLE
Add content pool and daily snacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Whether you're brushing up on Python, diving into C++, or just want a small chal
 A lightweight web and desktop-friendly app that gives you:
 
 - 🧩 **1–2 Daily Programming Challenges** (beginner to intermediate)  
-- 💬 **Hints, jokes, and quick facts** to keep it engaging  
+- 💬 **Hints, jokes, and quick facts** to keep it engaging
+- 🎉 **Random daily snacks** on the homepage
 - 🛠️ Support for **Python, C++, JavaScript, Java, and C#** (more to come)  
 - 📊 **Progress tracking** and personalized language preferences  
 - 🤖 Future-proof with optional **LLM-generated content** (human-reviewed)  

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash
 from flask_login import login_required, current_user
-from ..models import Challenge, UserProgress, db
+from sqlalchemy.sql import func
+from ..models import Challenge, Snack, UserProgress, db
 from ..utils import select_daily_challenge_for
 
 main_bp = Blueprint("main", __name__)
@@ -9,8 +10,14 @@ main_bp = Blueprint("main", __name__)
 def index():
     if current_user.is_authenticated:
         return redirect(url_for("main.dashboard"))
-    # show marketing home page for visitors
-    return render_template("home.html")
+    # show marketing home page for visitors along with random content
+    challenge = Challenge.query.order_by(func.random()).first()
+    snacks = {
+        "hint": Snack.query.filter_by(category="hint", approved=True).order_by(func.random()).first(),
+        "joke": Snack.query.filter_by(category="joke", approved=True).order_by(func.random()).first(),
+        "fact": Snack.query.filter_by(category="fact", approved=True).order_by(func.random()).first(),
+    }
+    return render_template("home.html", challenge=challenge, snacks=snacks)
 
 @main_bp.route("/dashboard")
 @login_required

--- a/app/models.py
+++ b/app/models.py
@@ -46,3 +46,17 @@ class UserProgress(db.Model):
 
     user = db.relationship("User", backref="progress")
     challenge = db.relationship("Challenge")
+
+
+class Snack(db.Model):
+    """Simple content pool for hints, jokes and quick facts."""
+
+    __tablename__ = "snacks"
+
+    id = db.Column(db.Integer, primary_key=True)
+    category = db.Column(db.String(40), nullable=False)  # hint, joke, fact
+    text = db.Column(db.Text, nullable=False)
+    is_llm = db.Column(db.Boolean, default=False)
+    approved = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -29,4 +29,35 @@
         <p>Practice Python, JavaScript, C++, and more.</p>
     </div>
 </section>
+
+<section class="snacks">
+    {% if challenge %}
+    <div class="snack glass">
+        <h3>Today's Challenge</h3>
+        <strong>{{ challenge.title }}</strong>
+        <p>{{ challenge.prompt }}</p>
+    </div>
+    {% endif %}
+
+    {% if snacks.hint %}
+    <div class="snack glass">
+        <h3>Hint</h3>
+        <p>{{ snacks.hint.text }}</p>
+    </div>
+    {% endif %}
+
+    {% if snacks.joke %}
+    <div class="snack glass">
+        <h3>Joke</h3>
+        <p>{{ snacks.joke.text }}</p>
+    </div>
+    {% endif %}
+
+    {% if snacks.fact %}
+    <div class="snack glass">
+        <h3>Quick Fact</h3>
+        <p>{{ snacks.fact.text }}</p>
+    </div>
+    {% endif %}
+</section>
 {% endblock %}

--- a/seed.py
+++ b/seed.py
@@ -1,5 +1,5 @@
 from app import create_app
-from app.models import db, Challenge, User, UserProgress
+from app.models import db, Challenge, Snack, User, UserProgress
 import json
 
 app = create_app()
@@ -29,3 +29,11 @@ with app.app_context():
     db.session.add_all([c1, c2])
     db.session.commit()
     print("Seeded challenges.")
+
+    # sample snacks
+    s1 = Snack(category="hint", text="Remember to keep functions small and focused.")
+    s2 = Snack(category="joke", text="Why do programmers prefer dark mode? Because light attracts bugs!")
+    s3 = Snack(category="fact", text="Python was named after Monty Python, not the snake.")
+    db.session.add_all([s1, s2, s3])
+    db.session.commit()
+    print("Seeded snacks.")


### PR DESCRIPTION
## Summary
- introduce `Snack` model for hints, jokes, and quick facts
- seed initial snack data
- show random challenge and snacks on the home page
- update README with new feature

## Testing
- `pytest -q`
- `python -m py_compile app/models.py app/main/routes.py seed.py`


------
https://chatgpt.com/codex/tasks/task_e_688cc546db04832a80a1b68e2eef7963